### PR TITLE
[codevoyager] fix: _RetryAttempt.__exit__ no longer suppresses KeyboardInterrupt, SystemExit, GeneratorExit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.5 - 2026-07-17
+
+- Fix `_RetryAttempt.__exit__` swallowing `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` (#39). `__exit__` now only suppresses `Exception` subclasses, letting `BaseException` subclasses propagate naturally. (codevoyager-ai-dev)
+
 ## 4.2.4 - 2026-07-15
 
 - Fix `_maybe_call` swallowing legitimate `TypeError` exceptions from called functions (#48). Previously all `TypeError` exceptions were caught and silenced; now only argument-mismatch errors cause the fallback to return the callable, while real bugs propagate. (fazalpsinfo-cmyk)

--- a/backon/_retry/_classes.py
+++ b/backon/_retry/_classes.py
@@ -35,7 +35,7 @@ class _RetryAttempt:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is not None:
+        if exc_type is not None and issubclass(exc_type, Exception):
             self._exception = exc_val
             return True
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "backon"
-version = "4.2.4"
+version = "4.2.5"
 description = "Function decoration for backoff and retry"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -669,6 +669,30 @@ class TestRetryAttempt:
             raise RuntimeError("caught")
         assert attempt.failed
 
+    def test_attempt_does_not_suppress_keyboard_interrupt(self):
+        attempt = _RetryAttempt()
+        with pytest.raises(KeyboardInterrupt):
+            with attempt:
+                raise KeyboardInterrupt()
+        assert not attempt.failed
+        assert attempt.exception is None
+
+    def test_attempt_does_not_suppress_system_exit(self):
+        attempt = _RetryAttempt()
+        with pytest.raises(SystemExit):
+            with attempt:
+                raise SystemExit(1)
+        assert not attempt.failed
+        assert attempt.exception is None
+
+    def test_attempt_does_not_suppress_generator_exit(self):
+        attempt = _RetryAttempt()
+        with pytest.raises(GeneratorExit):
+            with attempt:
+                raise GeneratorExit()
+        assert not attempt.failed
+        assert attempt.exception is None
+
     def test_attempt_multiple_calls(self):
         attempt = _RetryAttempt()
         with attempt:


### PR DESCRIPTION
## Summary

_RetryAttempt.__exit__ was returning True for all exception types, including BaseException subclasses like KeyboardInterrupt, SystemExit, and GeneratorExit. This violated PEP 442 and silently swallowed Ctrl+C when using the iterator protocol with context managers.

## Changes

- **backon/_retry/_classes.py**: Changed `_RetryAttempt.__exit__` to only suppress `Exception` subclasses, not `BaseException` subclasses
- **pyproject.toml**: Bumped version from 4.2.4 to 4.2.5
- **tests/test_advanced_features.py**: Added tests for KeyboardInterrupt, SystemExit, and GeneratorExit not being suppressed

## Testing

- `ruff check backon/ tests/` — zero warnings
- `pytest tests/ -q` — 578 passed
- Added 3 new tests verifying that BaseException subclasses propagate correctly

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Retry handling no longer suppresses critical system-level exceptions such as keyboard interrupts, shutdown signals, or generator termination.
  - Retry attempts now correctly preserve normal application behavior when these exceptions occur.

- **Tests**
  - Added coverage confirming critical exceptions are re-raised and retry state remains accurate.

- **Chores**
  - Updated the package version to 4.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->