### PR TITLE
[codevoyager] fix: trio timeout retry broken - AttemptTimeoutError never caught

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.5 - 2026-07-17
+
+- Fix trio timeout retry completely broken (#50). `attempt_timeout` in `retry_predicate` and `retry_exception` raised `AttemptTimeoutError` inside the same `try` block that was supposed to catch it — the handler was a sibling `except` clause, so it never matched and the exception escaped the retry loop. Fixed by nesting the timeout-try inside a second `try` so the converted `AttemptTimeoutError` is properly caught. Also fixed `ret` being unbound when timeout exhausts `max_tries` in the predicate path. (codevoyager-ai-dev)
+
 ## 4.2.4 - 2026-07-15
 
 - Fix `_maybe_call` swallowing legitimate `TypeError` exceptions from called functions (#48). Previously all `TypeError` exceptions were caught and silenced; now only argument-mismatch errors cause the fallback to return the callable, while real bugs propagate. (fazalpsinfo-cmyk)

--- a/backon/_trio.py
+++ b/backon/_trio.py
@@ -96,6 +96,7 @@ def retry_predicate(
         tries = 0
         start = _now()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
+        ret = None
         while True:
             tries += 1
             elapsed = _elapsed(start)
@@ -110,13 +111,14 @@ def retry_predicate(
             await _call_handlers(on_attempt, **details)
 
             try:
-                if attempt_timeout is not None:
-                    with trio.fail_after(attempt_timeout):
+                try:
+                    if attempt_timeout is not None:
+                        with trio.fail_after(attempt_timeout):
+                            ret = await target(*args, **kwargs)
+                    else:
                         ret = await target(*args, **kwargs)
-                else:
-                    ret = await target(*args, **kwargs)
-            except trio.TooSlowError:
-                raise AttemptTimeoutError() from None
+                except trio.TooSlowError:
+                    raise AttemptTimeoutError() from None
             except AttemptTimeoutError:
                 max_tries_exceeded = tries == max_tries_value
                 max_time_exceeded = (
@@ -218,13 +220,14 @@ def retry_exception(
             await _call_handlers(on_attempt, **details)
 
             try:
-                if attempt_timeout is not None:
-                    with trio.fail_after(attempt_timeout):
+                try:
+                    if attempt_timeout is not None:
+                        with trio.fail_after(attempt_timeout):
+                            ret = await target(*args, **kwargs)
+                    else:
                         ret = await target(*args, **kwargs)
-                else:
-                    ret = await target(*args, **kwargs)
-            except trio.TooSlowError:
-                raise AttemptTimeoutError() from None
+                except trio.TooSlowError:
+                    raise AttemptTimeoutError() from None
             except AttemptTimeoutError:
                 max_tries_exceeded = tries == max_tries_value
                 max_time_exceeded = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "backon"
-version = "4.2.4"
+version = "4.2.5"
 description = "Function decoration for backoff and retry"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -1,10 +1,33 @@
-import pytest
+import contextlib
 
+import pytest
+import trio
+
+from backon._state import AttemptTimeoutError
 from backon._trio import retry_exception, retry_predicate
+from backon._wait_gen import constant
+
+
+def _make_predicate_target(rl):
+    async def target():
+        rl.append(1)
+        await trio.sleep(0.5)
+        return "ok"
+    return target
+
+
+def _make_exception_target(rl):
+    async def target():
+        rl.append(1)
+        await trio.sleep(0.5)
+        raise ValueError("fail")
+    return target
 
 
 class TestTrioNotInstalled:
-    def test_retry_predicate_raises_without_trio(self):
+    def test_retry_predicate_raises_without_trio(self, monkeypatch):
+        monkeypatch.setattr("backon._trio._trio_available", False)
+
         def target():
             return None
 
@@ -24,7 +47,9 @@ class TestTrioNotInstalled:
                 wait_gen_kwargs={},
             )
 
-    def test_retry_exception_raises_without_trio(self):
+    def test_retry_exception_raises_without_trio(self, monkeypatch):
+        monkeypatch.setattr("backon._trio._trio_available", False)
+
         def target():
             raise ValueError("fail")
 
@@ -48,15 +73,242 @@ class TestTrioNotInstalled:
 
 
 class TestTrioImports:
-    def test_trio_flag_false(self):
+    def test_trio_flag_true(self):
         from backon._trio import _trio_available
 
-        assert not _trio_available
+        assert _trio_available
 
-    def test_module_importable(self):
+    def test_trio_available_imports(self):
         import backon._trio as t
 
         assert hasattr(t, "retry_predicate")
         assert hasattr(t, "retry_exception")
         assert hasattr(t, "_trio_available")
-        assert not t._trio_available
+        assert t._trio_available
+
+
+class TestTrioAttemptTimeout:
+    def test_predicate_timeout_triggers_retry(self):
+        rl = []
+        wrapped = retry_predicate(
+            _make_predicate_target(rl),
+            constant,
+            lambda v: False,
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+            attempt_timeout=0.01,
+        )
+
+        with contextlib.suppress(Exception):
+            trio.run(wrapped)
+        assert len(rl) == 3
+
+    def test_exception_timeout_triggers_retry(self):
+        rl = []
+        wrapped = retry_exception(
+            _make_exception_target(rl),
+            constant,
+            ValueError,
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            giveup=lambda e: False,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            raise_on_giveup=False,
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+            attempt_timeout=0.01,
+        )
+
+        with contextlib.suppress(Exception):
+            trio.run(wrapped)
+        assert len(rl) == 3
+
+    def test_predicate_timeout_giveup_after_exhaustion(self):
+        rl = []
+        wrapped = retry_predicate(
+            _make_predicate_target(rl),
+            constant,
+            lambda v: False,
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+            attempt_timeout=0.01,
+        )
+
+        trio.run(wrapped)
+        assert len(rl) == 3
+
+    def test_exception_timeout_giveup_after_exhaustion(self):
+        rl = []
+        wrapped = retry_exception(
+            _make_exception_target(rl),
+            constant,
+            ValueError,
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            giveup=lambda e: False,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            raise_on_giveup=False,
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+            attempt_timeout=0.01,
+        )
+
+        result = trio.run(wrapped)
+        assert result is None
+        assert len(rl) == 3
+
+    def test_exception_timeout_raises_on_giveup(self):
+        rl = []
+        wrapped = retry_exception(
+            _make_exception_target(rl),
+            constant,
+            ValueError,
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            giveup=lambda e: False,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            raise_on_giveup=True,
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+            attempt_timeout=0.01,
+        )
+
+        with pytest.raises(AttemptTimeoutError):
+            trio.run(wrapped)
+        assert len(rl) == 3
+
+    def test_no_timeout_predicate_succeeds(self):
+        rl = []
+
+        async def target():
+            rl.append(1)
+            return "ok"
+
+        wrapped = retry_predicate(
+            target,
+            constant,
+            lambda v: False,
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+            attempt_timeout=999,
+        )
+
+        result = trio.run(wrapped)
+        assert result == "ok"
+        assert len(rl) == 1
+
+    def test_no_timeout_exception_succeeds(self):
+        rl = []
+
+        async def target():
+            rl.append(1)
+            return "ok"
+
+        wrapped = retry_exception(
+            target,
+            constant,
+            Exception,
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            giveup=lambda e: False,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            raise_on_giveup=False,
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+            attempt_timeout=999,
+        )
+
+        result = trio.run(wrapped)
+        assert result == "ok"
+        assert len(rl) == 1
+
+    def test_predicate_retry_without_timeout(self):
+        rl = []
+
+        async def target():
+            rl.append(1)
+            return "retry"
+
+        wrapped = retry_predicate(
+            target,
+            constant,
+            lambda v: v == "retry",
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+        )
+
+        result = trio.run(wrapped)
+        assert result == "retry"
+        assert len(rl) == 3
+
+    def test_exception_retry_without_timeout(self):
+        rl = []
+
+        async def target():
+            rl.append(1)
+            raise ValueError("fail")
+
+        wrapped = retry_exception(
+            target,
+            constant,
+            ValueError,
+            max_tries=3,
+            max_time=None,
+            jitter=None,
+            giveup=lambda e: False,
+            on_success=[],
+            on_backoff=[],
+            on_giveup=[],
+            on_attempt=[],
+            raise_on_giveup=False,
+            sleep=trio.sleep,
+            wait_gen_kwargs={"interval": 0},
+        )
+
+        result = trio.run(wrapped)
+        assert result is None
+        assert len(rl) == 3


### PR DESCRIPTION
Fix #50: trio timeout retry completely broken.

**Root cause:** In `backon/_trio.py`, both `retry_predicate` and `retry_exception` had a nested-except bug. When `trio.TooSlowError` was raised by `trio.fail_after()`, the handler caught it and raised `AttemptTimeoutError()` — but this `raise` happened inside the same `try` block as the `except AttemptTimeoutError` handler. Python's exception semantics prevent a `raise` inside one `except` from being caught by sibling `except` clauses, so the `AttemptTimeoutError` escaped the retry loop entirely.

**Fix:** Nested the timeout `try/except` inside an outer `try` so the `AttemptTimeoutError` raised from the `trio.TooSlowError` handler is properly caught by the outer `except AttemptTimeoutError`.

**Additional fix:** In `retry_predicate`, when timeout exhausts `max_tries`, `ret` was never assigned before `return ret`, which would raise `UnboundLocalError`. Fixed by initializing `ret = None` before the loop.

**Tests added:** 13 tests in `tests/test_trio.py` covering:
- Predicate and exception timeout retry (timeout triggers retry up to max_tries)
- Timeout giveup after exhaustion (both predicate and exception paths)
- `raise_on_giveup=True` properly re-raising `AttemptTimeoutError`
- No-timeout success paths
- Basic retry without timeout (predicate and exception paths)
- Mocked 'trio not installed' tests still pass

**Verification:**
- `ruff check backon/ tests/` — all checks passed
- `mypy backon/` — zero new errors (pre-existing `_hedging.py` error unchanged)
- `pytest tests/ -q` — 584 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Trio retry handling when an individual attempt exceeds its timeout.
  * Prevented timeout errors from escaping the retry loop unexpectedly.
  * Corrected behavior when all retry attempts are exhausted, including cases configured to raise on failure.
  * Improved reliability for both predicate-based and exception-based retries.

* **Documentation**
  * Added release notes for version 4.2.5, dated July 17, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->