### PR TITLE
Release v4.4.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@
 
 ## Release Process
 
-1. Bump `__version__` in `backon/__init__.py` and `version` in `pyproject.toml`.
+1. Bump `version` in `pyproject.toml` (the single source of truth; `__version__` in `backon/__init__.py` is read dynamically from `importlib.metadata`).
 2. Update `CHANGELOG.md` with the new version, date, and changes.
 3. Commit with message `Release vX.Y.Z`.
 4. Push to `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.4.2 - 2026-07-22
+
+- Documentation: remove stale Metrics references from README. The metrics instrumentation (`MetricsCollector`, `PrometheusMetrics`, `OTelMetrics`, `StructlogMetrics`, `get_metrics_collector`, `set_metrics_collector`) was removed as dead code in 4.3.0, but the README still listed a `[Metrics](#metrics)` ToC entry (broken link), advertised "Prometheus / OpenTelemetry / structlog metrics" in the Features list, and included a "Metrics | Prometheus / OTel" row in the migration table. All three references are now gone.
+- Documentation: fix `AGENTS.md` Release Process step 1, which instructed to bump `__version__` in `backon/__init__.py`. That value is read dynamically from `importlib.metadata`; only `version` in `pyproject.toml` needs bumping. Now consistent with the Versioning section.
+
+Note: mypy `python_version` stays at `3.10` even though 4.4.0 restored Python 3.9 runtime support. mypy 2.x dropped `python_version = "3.9"` (minimum supported target is 3.10); 3.9 compatibility is enforced via `Union`/`Optional` in module-level aliases, `from __future__ import annotations` in `_decorator.py`, and the Python 3.9 entry in the CI matrix.
+
 ## 4.4.1 - 2026-07-21
 
 - Fix `raise_on_giveup=False` silently swallowing `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` (#31). All retry loops (fast and slow, sync and async) now use `except Exception` instead of `except BaseException`, letting control-flow exceptions propagate naturally.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ backon is a modern evolution of [backoff](https://github.com/litl/backoff) — a
 - [Advanced Features](#advanced-features)
   - [Circuit Breaker](#circuit-breaker)
   - [Hedging](#hedging)
-  - [Metrics](#metrics)
   - [Testing Utilities](#testing-utilities)
   - [Trio Support](#trio-support)
   - [Retry Context Inspection](#retry-context-inspection)
@@ -101,7 +100,6 @@ backon is a modern evolution of [backoff](https://github.com/litl/backoff) — a
 - **Rich callbacks** — `on_attempt`, `on_backoff`, `on_success`, `on_giveup`, `before_sleep`, `before`, `after`
 - **Circuit breaker** — CLOSED/OPEN/HALF_OPEN states with automatic recovery
 - **Hedging** — concurrent retry requests, first-success-wins
-- **Prometheus / OpenTelemetry / structlog metrics** — optional, zero hard dependencies
 - **Testing module** — `disable_retries()`, `limit_retries()`, `remove_backoff()`, `assert_retried()`
 - **Trio support** — retry with the trio async framework
 - **Operator overloading** — compose stops with `|` / `&`, wait generators with `+`
@@ -786,7 +784,6 @@ Key differences:
 | Custom sleep | Not supported | `sleep=` parameter |
 | Circuit breaker | Not supported | `CircuitBreaker` + `BreakerRetrying` |
 | Hedging | Not supported | `hedge()` / `on_hedge()` |
-| Metrics | Not supported | Prometheus / OTel |
 | Wait generator composition | Not supported | `+` operator |
 | Stop / RetryCondition composition | Not supported | `\|` / `&` operators |
 | Trio | Not supported | `backon._trio` (deliberately private, optional dep) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "backon"
-version = "4.4.1"
+version = "4.4.2"
 description = "Function decoration for backoff and retry"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## 4.4.2 - 2026-07-22

- Documentation: remove stale Metrics references from README. The metrics instrumentation (`MetricsCollector`, `PrometheusMetrics`, `OTelMetrics`, `StructlogMetrics`, `get_metrics_collector`, `set_metrics_collector`) was removed as dead code in 4.3.0, but the README still listed a `[Metrics](#metrics)` ToC entry (broken link), advertised "Prometheus / OpenTelemetry / structlog metrics" in the Features list, and included a "Metrics | Prometheus / OTel" row in the migration table. All three references are now gone.
- Documentation: fix `AGENTS.md` Release Process step 1, which instructed to bump `__version__` in `backon/__init__.py`. That value is read dynamically from `importlib.metadata`; only `version` in `pyproject.toml` needs bumping. Now consistent with the Versioning section.

Note: mypy `python_version` stays at `3.10` even though 4.4.0 restored Python 3.9 runtime support. mypy 2.x dropped `python_version = "3.9"` (minimum supported target is 3.10); 3.9 compatibility is enforced via `Union`/`Optional` in module-level aliases, `from __future__ import annotations` in `_decorator.py`, and the Python 3.9 entry in the CI matrix.

**Validation:** All checks pass — ruff, mypy, and 563 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release-process guidance to use the project metadata version as the single source of truth.
  * Removed outdated metrics, Prometheus, OpenTelemetry, and structlog references from the README.
  * Added release notes for version 4.4.2, including Python support and documentation corrections.

* **Release**
  * Bumped the package version to 4.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->