### PR TITLE
Revert coverage fail_under to 95%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ branch = true
 command_line = "-m pytest"
 
 [tool.coverage.report]
-fail_under = 100
+fail_under = 95
 show_missing = true
 skip_empty = true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted the minimum required test coverage threshold to 95%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->